### PR TITLE
release-to-main-02

### DIFF
--- a/models/marts/bdg_tags.sql
+++ b/models/marts/bdg_tags.sql
@@ -1,0 +1,57 @@
+with
+
+questions_tags as (
+
+  select *
+  from {{ ref( 'stg_tags' ) }}
+
+),
+
+split_tags as (
+
+  select
+    question_id,
+    split(tags, '|') as some_tags
+  
+  from questions_tags
+
+),
+
+bridge_keys as (
+
+  select distinct
+    question_id,
+    flattened_tag
+
+  from split_tags
+  cross join split_tags.some_tags as flattened_tag
+),
+
+dim_question as (
+
+    select
+        rowid,
+        question_id
+    
+    from {{ ref( 'dim_question' ) }}
+),
+
+dim_tag as (
+
+    select *
+    from {{ ref( 'dim_tag' ) }}
+),
+
+bdg_tags as (
+
+  select
+    dim_question.rowid as question_rowid,
+    dim_tag.rowid as tag_rowid
+
+  from bridge_keys
+
+  left join dim_question on bridge_keys.question_id = dim_question.question_id
+  left join dim_tag on bridge_keys.flattened_tag = dim_tag.tag
+)
+
+select * from bdg_tags

--- a/models/marts/dim_tag.sql
+++ b/models/marts/dim_tag.sql
@@ -1,0 +1,27 @@
+with
+
+split_tags as (
+
+  select split(tags, '|') as some_tags
+  from {{ ref( 'stg_tags' ) }}
+
+),
+
+all_tags as (
+
+  select distinct tag
+  from split_tags
+  cross join split_tags.some_tags as tag
+
+),
+
+dim_tag as (
+
+  select
+    row_number() over ( order by tag ) as rowid,
+    tag
+  
+  from all_tags
+)
+
+select * from dim_tag

--- a/models/marts/tbl_totals_by_tag.sql
+++ b/models/marts/tbl_totals_by_tag.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        materialized = "view"
+    )
+}}
+
+with
+
+bdg_tags as (
+
+    select *
+    from {{ ref( 'bdg_tags' ) }}
+),
+
+dim_tag as (
+
+    select *
+    from {{ ref( 'dim_tag' ) }}
+),
+
+dim_question as (
+
+    select rowid
+    from {{ ref( 'dim_question' ) }}
+),
+
+fct_posts_questions as (
+
+    select
+
+        question_rowid,
+        creation_date_id,
+
+        answer_count,
+        view_count
+    
+    from {{ ref( 'fct_posts_questions' ) }}
+),
+
+tbl_totals_by_tag as (
+
+    select
+        t.tag,
+
+        count(b.question_rowid) as questions,
+        f.creation_date_id,
+
+        sum(f.answer_count) as answers,
+        sum(f.view_count) as views
+    
+    from bdg_tags as b
+
+    left join dim_tag as t on b.tag_rowid = t.rowid
+    left join dim_question as q on b.question_rowid = q.rowid
+    left join fct_posts_questions as f on f.question_rowid = q.rowid
+
+    group by
+        t.tag,
+        f.creation_date_id
+
+)
+
+select * from tbl_totals_by_tag

--- a/models/staging/stg_tags.sql
+++ b/models/staging/stg_tags.sql
@@ -1,0 +1,7 @@
+select
+    id as question_id,
+    tags
+  
+from {{ source( 'stackoverflow', 'posts_questions_202209' ) }}
+
+where id is not null


### PR DESCRIPTION
Second merge to _main_ to include an extension of the model consisting of the following.

_models/marts_
- _dim_tag.sql_: model the tag dimension
- _bdg_tags.sql_: model the bridge table between tags and questions
- _tbl_totals_by_tag.sql_: represents a table with answer and view totals by tag (and question creation date)