### PR TITLE
Analysis and macro

### DIFF
--- a/analyses/popular_topics_pct_of_answers.sql
+++ b/analyses/popular_topics_pct_of_answers.sql
@@ -1,0 +1,41 @@
+with
+
+selected_tags as (
+
+  select
+    b.tag,
+    sum( b.questions ) as n_questions, 
+    sum( b.answers ) as n_answers,
+    round( sum( b.answers ) / sum ( b.questions ), 2 ) as ratio_aq
+
+  from {{ ref( 'tbl_totals_by_tag' ) }} as b
+
+  where
+    b.tag in ( 
+        
+        {% for selected_tag in get_opportunity_tags(500, 20, 1500, 5000) -%}
+            '{{ selected_tag }}'
+            {%- if not loop.last -%}
+                ,
+            {%- endif %}
+        {% endfor %}
+    )
+    
+  group by b.tag
+
+),
+
+total_answers as (
+
+  select
+    sum(n_answers) as sum_answers
+  
+  from selected_tags
+)
+
+select
+  tag,
+  round( 100 * ( n_answers / sum_answers ), 1 ) as pct
+
+from selected_tags
+cross join total_answers

--- a/macros/get_opportunity_tags.sql
+++ b/macros/get_opportunity_tags.sql
@@ -1,0 +1,44 @@
+{% macro get_opportunity_tags(n_answers, n_tags, l_limit, r_limit) %}
+
+{%- call statement('opportunity_tags', fetch_result = True) -%}
+
+with
+
+    x_lowest_ratio_aq_tags_over_y_answers as (
+
+        select
+            tag,
+            sum(questions) as n_questions,
+            sum(answers) as n_answers,
+            round(sum(answers) / sum(questions), 2) as ratio_aq
+
+        from {{ ref('tbl_totals_by_tag') }}
+
+        group by tag
+        having n_answers > {{ n_answers }}
+
+        order by ratio_aq
+
+        limit {{ n_tags }}
+
+    )
+
+select tag
+from x_lowest_ratio_aq_tags_over_y_answers
+where n_answers between {{ l_limit }} and {{ r_limit }}
+
+{%- endcall -%}
+
+{%- set statement_data = load_result('opportunity_tags')['data'] -%}
+
+{%- set extract_values = [] -%}
+
+{%- for column_values in statement_data -%}
+{% do extract_values.append( column_values[0] ) %}
+{%- endfor %}
+
+{%- set distinct_values = extract_values | unique | list | sort -%}
+
+{{ return( distinct_values ) }}
+
+{% endmacro %}


### PR DESCRIPTION
analyses
	- popular_topics_pct_of_answers.sql: calculates the % of answers for a group of tags selected by two conditions:

> 1) X tags with the lowest answer-question ratio over Y answers
> 2) Out of the result in 1, the tags with a # of answers between a range [l_limit, r_limit]
> 

macros
	- get_opportunity_tags.sql: retrieves the group of tags to be used in the analysis