### PR TITLE
release-to-main-03

### DIFF
--- a/analyses/popular_topics_pct_of_answers.sql
+++ b/analyses/popular_topics_pct_of_answers.sql
@@ -1,0 +1,41 @@
+with
+
+selected_tags as (
+
+  select
+    b.tag,
+    sum( b.questions ) as n_questions, 
+    sum( b.answers ) as n_answers,
+    round( sum( b.answers ) / sum ( b.questions ), 2 ) as ratio_aq
+
+  from {{ ref( 'tbl_totals_by_tag' ) }} as b
+
+  where
+    b.tag in ( 
+        
+        {% for selected_tag in get_opportunity_tags(500, 20, 1500, 5000) -%}
+            '{{ selected_tag }}'
+            {%- if not loop.last -%}
+                ,
+            {%- endif %}
+        {% endfor %}
+    )
+    
+  group by b.tag
+
+),
+
+total_answers as (
+
+  select
+    sum(n_answers) as sum_answers
+  
+  from selected_tags
+)
+
+select
+  tag,
+  round( 100 * ( n_answers / sum_answers ), 1 ) as pct
+
+from selected_tags
+cross join total_answers

--- a/macros/get_opportunity_tags.sql
+++ b/macros/get_opportunity_tags.sql
@@ -1,0 +1,44 @@
+{% macro get_opportunity_tags(n_answers, n_tags, l_limit, r_limit) %}
+
+{%- call statement('opportunity_tags', fetch_result = True) -%}
+
+with
+
+    x_lowest_ratio_aq_tags_over_y_answers as (
+
+        select
+            tag,
+            sum(questions) as n_questions,
+            sum(answers) as n_answers,
+            round(sum(answers) / sum(questions), 2) as ratio_aq
+
+        from {{ ref('tbl_totals_by_tag') }}
+
+        group by tag
+        having n_answers > {{ n_answers }}
+
+        order by ratio_aq
+
+        limit {{ n_tags }}
+
+    )
+
+select tag
+from x_lowest_ratio_aq_tags_over_y_answers
+where n_answers between {{ l_limit }} and {{ r_limit }}
+
+{%- endcall -%}
+
+{%- set statement_data = load_result('opportunity_tags')['data'] -%}
+
+{%- set extract_values = [] -%}
+
+{%- for column_values in statement_data -%}
+{% do extract_values.append( column_values[0] ) %}
+{%- endfor %}
+
+{%- set distinct_values = extract_values | unique | list | sort -%}
+
+{{ return( distinct_values ) }}
+
+{% endmacro %}

--- a/models/marts/stackoverflow.yml
+++ b/models/marts/stackoverflow.yml
@@ -1,0 +1,135 @@
+version: 2
+
+models:
+
+  - name: fct_posts_questions
+    description: "Each record represents a question with its owner asked at a creation date. Includes the last activity and last edit dates. For each question, there are available the measures listed below."
+    columns:
+
+      - name: question_rowid
+        description: Row id to dim_question
+    
+      - name: owner_rowid
+        description: Row id to dim_owner
+    
+      - name: creation_date_id
+        description: Id to role-playing dimension dim_creation_date
+    
+      - name: last_activity_date_id
+        description: Id to role-playing dimension dim_last_activity_date
+    
+      - name: last_edit_date_id
+        description: Id to role-playing dimension dim_last_edit_date
+    
+      - name: answer_count
+        description: '# of answers to a question'
+    
+      - name: comment_count
+        description: '# of comments to a question'
+    
+      - name: favorite_count
+        description: '# of times a question has been marked as favorite'
+    
+      - name: view_count
+        description: '# of times a question has been viewed'
+    
+      - name: score
+        description: Value that represents the usefullness of a question
+
+
+  - name: int_date__as_of_2000
+    description: Integration model to base the role-playing date dimensions on. Contains records from 01/01/2000 until 31/12/2024. Includes a record for unknown dates (01/01/1900).
+    columns:
+
+      - name: date_id
+        description: Rowid in the form YYYYMMDD
+
+      - name: date
+        description: The date
+        
+      - name: year
+        description: Year number in the form YYYY
+        
+      - name: quarter
+        description: Quarter number in the form Q
+        
+      - name: month
+        description: Month number in the form MM
+        
+      - name: day
+        description: Day number in the form DD
+        
+      - name: week_day_desc
+        description: Day of the week (Monday, ..., Sunday)
+        
+
+  - name: bdg_tags
+    description: Bridge table that establishes an N:M relationship between tag and question dimensions
+    columns:
+
+      - name: question_rowid
+        description: Row id to dim_question
+      
+      - name: tag_rowid
+        description: Row id to dim_tag
+      
+
+  - name: tbl_totals_by_tag_and_date
+    description: View that computes several totals by tag and date to be used for reporting
+    columns:
+
+      - name: tag
+        description: The tag
+
+      - name: creation_date
+        description: The creation date of the questions where the tag appears
+
+      - name: questions
+        description: Total number of questions where a tag appears by question creation date
+
+      - name: answers
+        description: Total number of answers to questions where a tag appears by question creation date
+
+      - name: views
+        description: Total number of views of questions where a tag appears by creation date
+        
+      
+
+macros:
+
+  - name: get_opportunity_tags
+    description: Extracts a list of tags that are considered to be an opportunity for developers to answer or a risk of churn of users. Gets the 'n_tags' lowest ratio answers-questions tags over 'n_answers' answers, and reduces the tags to those with a number of answers in the range 'l_limit' and 'r_limit'.
+    arguments:
+    
+      - name: n_answers
+        type: integer
+        description: There must be more than this number of answers to consider a tag relevant.
+      - name: n_tags
+        type: integer
+        description: The number of tags with the lowest answers-questions ratio (answers/questions).
+      - name: l_limit
+        type: integer
+        description: Out of the n_tags gathered, defines the range left limit of the number of answers to select the final tags.
+      - name: r_limit
+        type: integer
+        description: Out of the n_tags gathered, defines the range right limit of the number of answers to select the final tags.
+
+
+  - name: not_less_than_zero
+    description: Custom generic test that checks the value of a column in a model is not negative
+    arguments:
+
+      - name: model
+        type: string
+        description: The model on which the test is defined
+
+      - name: column_name
+        type: string
+        description: The column on which the test is defined
+
+
+
+analyses:
+
+  - name: popular_topics_pct_of_answers
+    description: Calculates the % of answers for each tag within the group of tags gathered by the macro 'get_opportunity_tags'. Helps understand, combined with the answers-questions ratio, which of those tags may be worth putting more effort on. [ There is a page in a report on Looker Studio with this analysis ]

--- a/models/staging/stg_stackoverflow.yml
+++ b/models/staging/stg_stackoverflow.yml
@@ -3,6 +3,7 @@ version: 2
 models:
 
   - name: stg_posts_questions
+    description: Staging table of facts for model 'fct_posts_questions'
     columns:
 
       - name: question_id
@@ -32,3 +33,27 @@ models:
       - name: view_count
         tests:
           - not_less_than_zero
+
+
+  - name: stg_owners
+    description: Staging table for the owner dimension (model 'dim_owner')
+
+
+  - name: stg_questions
+    description: Staging table for the question dimension (model 'dim_question')
+
+
+  - name: stg_tags
+    description: Staging table of facts for model 'bdg_tags'
+    columns:
+
+      - name: question_id
+        description: Id to the staging model for questions
+        tests:
+          - relationships:
+              to: ref('stg_questions')
+              field: question_id
+      
+      - name: tags
+        description: String that contains all the tags for a question separated by '|'.
+      

--- a/models/staging/stg_stackoverflow.yml
+++ b/models/staging/stg_stackoverflow.yml
@@ -1,0 +1,34 @@
+version: 2
+
+models:
+
+  - name: stg_posts_questions
+    columns:
+
+      - name: question_id
+        tests:
+          - relationships:
+              to: ref('stg_questions')
+              field: question_id
+
+      - name: owner_id
+        tests:
+          - relationships:
+              to: ref('stg_owners')
+              field: owner_id
+
+      - name: answer_count
+        tests:
+          - not_less_than_zero
+
+      - name: comment_count
+        tests:
+          - not_less_than_zero
+
+      - name: favorite_count
+        tests:
+          - not_less_than_zero
+      
+      - name: view_count
+        tests:
+          - not_less_than_zero

--- a/tests/generic/not_less_than_zero.sql
+++ b/tests/generic/not_less_than_zero.sql
@@ -1,0 +1,7 @@
+{% test not_less_than_zero (model, column_name) %}
+
+    select *
+    from {{ model }}
+    where {{ column_name }} < 0
+
+{% endtest %}


### PR DESCRIPTION
**models/marts**
- tbl_totals_by_tag_and_date.sql: based on tbl_totals_by_tags.sql adding creation date
- stackoverflow.yml: includes description of models and columns

**models/staging**
- stg_stackoverflow.yml: configuration of the generic test defined and relationships dbt test
- stg_stackoverflow.yml: modified to include description of tables and columns

**analyses**
queries that will be replicated in Looker Studio
- 20_lowest_ratio_aq_tags.sql
- 20_most_answered_tags.sql
- popular_topics_pct_of_answers.sql: calculates the % of answers for a group of tags selected by two conditions:

1. X tags with the lowest answer-question ratio over Y answers
2. Out of the result in 1, the tags with a # of answers between a range [l_limit, r_limit]

**macros**
- get_opportunity_tags.sql: retrieves the group of tags to be used in the analysis

**tests/generic**
- not_less_than_zero.sql: ensures that a measure has positive values

