### PR TITLE
hotfix-to-main

### DIFF
--- a/macros/limit_data.sql
+++ b/macros/limit_data.sql
@@ -1,0 +1,7 @@
+{% macro limit_data (column_name, start_date, end_date) %}
+
+    {% if target.name == 'default' %}
+    where {{ column_name }} >= cast( '{{ start_date }}' as timestamp ) and {{ column_name }} < cast( '{{ end_date }}' as timestamp )
+    {% endif %}
+
+{% endmacro %}

--- a/models/marts/dim_question.sql
+++ b/models/marts/dim_question.sql
@@ -4,8 +4,7 @@ unknown_question as (
 
     select
         -1 as question_id,
-        'Unknown' as title,
-        'Unknown' as body
+        'Unknown' as title
 ),
 
 questions as (

--- a/models/source/posts_questions.sql
+++ b/models/source/posts_questions.sql
@@ -1,0 +1,29 @@
+{{ config( schema = 'src' ) }}
+
+select
+    -- questions
+    id,
+    title,
+
+    -- owners
+    owner_user_id,
+    owner_display_name,
+
+    -- tags
+    tags,
+
+    -- dates
+    creation_date,
+    last_activity_date,
+    last_edit_date,
+
+    -- measures
+    answer_count,
+    comment_count,
+    favorite_count,
+    view_count,
+    score
+
+from {{ source( 'public_stackoverflow', 'posts_questions' ) }}
+
+{{ limit_data( 'creation_date', '2022-08-01', '2022-09-25' ) }}

--- a/models/source/src_public_stackoverflow.yml
+++ b/models/source/src_public_stackoverflow.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+
+  - name: public_stackoverflow
+    database: bigquery-public-data
+    schema: stackoverflow
+    tables:
+      - name: posts_questions

--- a/models/staging/src_stackoverflow.yml
+++ b/models/staging/src_stackoverflow.yml
@@ -1,8 +1,16 @@
 version: 2
 
 sources:
+
   - name: stackoverflow
     database: earnest-cosmos-375111
     schema: stackoverflow
     tables:
       - name: posts_questions_202209
+  
+  - name: stackoverflow_src
+    database: earnest-cosmos-375111
+    schema: dbt_stackoverflow_src
+    tables:
+      - name: posts_questions
+

--- a/models/staging/stg_owners.sql
+++ b/models/staging/stg_owners.sql
@@ -2,6 +2,6 @@ select distinct
     owner_user_id as owner_id,
     owner_display_name as owner_name
     
-from {{ source( 'stackoverflow', 'posts_questions_202209' ) }}
+from {{ source( 'stackoverflow_src', 'posts_questions' ) }}
 
 where owner_user_id is not null

--- a/models/staging/stg_posts_questions.sql
+++ b/models/staging/stg_posts_questions.sql
@@ -15,4 +15,4 @@ select
     view_count,
     score
 
-from {{ source( 'stackoverflow', 'posts_questions_202209' ) }}
+from {{ source( 'stackoverflow_src', 'posts_questions' ) }}

--- a/models/staging/stg_questions.sql
+++ b/models/staging/stg_questions.sql
@@ -1,8 +1,7 @@
 select
     id as question_id,
-    title,
-    body
+    title
 
-from {{ source('stackoverflow', 'posts_questions_202209') }}
+from {{ source( 'stackoverflow_src', 'posts_questions' ) }}
 
 where id is not null

--- a/models/staging/stg_tags.sql
+++ b/models/staging/stg_tags.sql
@@ -2,6 +2,6 @@ select
     id as question_id,
     tags
   
-from {{ source( 'stackoverflow', 'posts_questions_202209' ) }}
+from {{ source( 'stackoverflow_src', 'posts_questions' ) }}
 
 where id is not null


### PR DESCRIPTION
**Files added**

_macros/_

- limit_data.sql: macro to filter data by a date column, a start date and an end date

_models/source/_

- src_public_stackoverflow.yml: configuration of a source from the bigquery public data
- posts_questions.sql: definition of the source model in a different schema, limiting data to a sample


**Files modified**

_models/marts/_

- dim_question.sql: column ‘body’ has been removed

	
_models/staging/_

- src_stackoverflow.yml: added the new source configured in models/source/src_public_stackoverlow.yml
- stg_owners.sql, stg_posts_questions.sql, stg_questions.sql and stg_tags.sql: all use now the new source